### PR TITLE
Fix newlines in `description`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+"""
+Sphinx directive for "sessions", like typing into a console or Python prompt.
+"""
+
 import os
 
 from setuptools import setup, find_packages
@@ -22,9 +26,7 @@ tests_require = [
 setup(
     name='sphinxcontrib-session',
     version='0.0.1',
-    description="""
-Sphinx directive for "sessions", like typing into a console or Python prompt.
-""",
+    description=__doc__.strip(),
     long_description=README,
     long_description_content_type='text/x-rst',
     classifiers=[


### PR DESCRIPTION
Fixes the following error;
```
    File "env/lib/python3.7/site-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    File "env/lib/python3.7/site-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed
```

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>