### PR TITLE
Update to use `add_css_file`.

### DIFF
--- a/sphinxcontrib_session/__init__.py
+++ b/sphinxcontrib_session/__init__.py
@@ -154,8 +154,8 @@ def _is_html(app):
     return app.builder.name in ('html', 'readthedocs')
 
 
-def add_stylesheet(app):
-    app.add_stylesheet('session.css')
+def add_css_file(app):
+    app.add_css_file('session.css')
 
 
 def copy_stylesheet(app, exception):
@@ -169,7 +169,7 @@ def copy_stylesheet(app, exception):
 # --------------------------
 
 def setup(app):
-    app.connect('builder-inited', add_stylesheet)
+    app.connect('builder-inited', add_css_file)
     app.connect('build-finished', copy_stylesheet)
     app.add_directive('session', SessionDirective)
     app.add_node(session, html=(visit_session_html, depart_session_html))


### PR DESCRIPTION
`add_stylesheet` as deprecated at Sphinx 1.8.0 and replaced with `add_css_file`. See https://github.com/sphinx-doc/sphinx/issues/7747